### PR TITLE
Per-task Pareto softmax-sum candidate selector with temperature and -Inf handling

### DIFF
--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -21,6 +21,7 @@ from gepa.strategies.candidate_selector import (
     CurrentBestCandidateSelector,
     EpsilonGreedyCandidateSelector,
     ParetoCandidateSelector,
+    ParetoSoftmaxSumCandidateSelector,
 )
 from gepa.strategies.component_selector import (
     AllReflectionComponentSelector,
@@ -38,7 +39,8 @@ def optimize(
     task_lm: str | ChatCompletionCallable | None = None,
     # Reflection-based configuration
     reflection_lm: LanguageModel | str | None = None,
-    candidate_selection_strategy: CandidateSelector | Literal["pareto", "current_best", "epsilon_greedy"] = "pareto",
+    candidate_selection_strategy: CandidateSelector
+    | Literal["pareto", "pareto_softmax_sum", "current_best", "epsilon_greedy"] = "pareto",
     skip_perfect_score: bool = True,
     batch_sampler: BatchSampler | Literal["epoch_shuffled"] = "epoch_shuffled",
     reflection_minibatch_size: int | None = None,
@@ -114,7 +116,7 @@ def optimize(
 
     # Reflection-based configuration
     - reflection_lm: A `LanguageModel` instance that is used to reflect on the performance of the candidate program.
-    - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'current_best', 'epsilon_greedy'. Defaults to 'pareto'.
+    - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'pareto_softmax_sum', 'current_best', 'epsilon_greedy'. Defaults to 'pareto'.
     - skip_perfect_score: Whether to skip updating the candidate if it achieves a perfect score on the minibatch.
     - batch_sampler: Strategy for selecting training examples. Can be a [BatchSampler](src/gepa/strategies/batch_sampler.py) instance or a string for a predefined strategy from ['epoch_shuffled']. Defaults to 'epoch_shuffled', which creates an [EpochShuffledBatchSampler](src/gepa/strategies/batch_sampler.py).
     - reflection_minibatch_size: The number of examples to use for reflection in each proposal step. Defaults to 3. Only valid when batch_sampler='epoch_shuffled' (default), and is ignored otherwise.
@@ -232,6 +234,7 @@ def optimize(
     if isinstance(candidate_selection_strategy, str):
         factories = {
             "pareto": lambda: ParetoCandidateSelector(rng=rng),
+            "pareto_softmax_sum": lambda: ParetoSoftmaxSumCandidateSelector(rng=rng),
             "current_best": lambda: CurrentBestCandidateSelector(),
             "epsilon_greedy": lambda: EpsilonGreedyCandidateSelector(epsilon=0.1, rng=rng),
         }
@@ -241,7 +244,7 @@ def optimize(
         except KeyError as exc:
             raise ValueError(
                 f"Unknown candidate_selector strategy: {candidate_selection_strategy}. "
-                "Supported strategies: 'pareto', 'current_best', 'epsilon_greedy'"
+                "Supported strategies: 'pareto', 'pareto_softmax_sum', 'current_best', 'epsilon_greedy'"
             ) from exc
     elif isinstance(candidate_selection_strategy, CandidateSelector):
         candidate_selector = candidate_selection_strategy

--- a/src/gepa/api.py
+++ b/src/gepa/api.py
@@ -21,7 +21,7 @@ from gepa.strategies.candidate_selector import (
     CurrentBestCandidateSelector,
     EpsilonGreedyCandidateSelector,
     ParetoCandidateSelector,
-    ParetoSoftmaxSumCandidateSelector,
+    ParetoSoftmaxCandidateSelector,
 )
 from gepa.strategies.component_selector import (
     AllReflectionComponentSelector,
@@ -40,7 +40,7 @@ def optimize(
     # Reflection-based configuration
     reflection_lm: LanguageModel | str | None = None,
     candidate_selection_strategy: CandidateSelector
-    | Literal["pareto", "pareto_softmax_sum", "current_best", "epsilon_greedy"] = "pareto",
+    | Literal["pareto", "pareto_softmax", "current_best", "epsilon_greedy"] = "pareto",
     skip_perfect_score: bool = True,
     batch_sampler: BatchSampler | Literal["epoch_shuffled"] = "epoch_shuffled",
     reflection_minibatch_size: int | None = None,
@@ -116,7 +116,7 @@ def optimize(
 
     # Reflection-based configuration
     - reflection_lm: A `LanguageModel` instance that is used to reflect on the performance of the candidate program.
-    - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'pareto_softmax_sum', 'current_best', 'epsilon_greedy'. Defaults to 'pareto'.
+    - candidate_selection_strategy: The strategy to use for selecting the candidate to update. Supported strategies: 'pareto', 'pareto_softmax', 'current_best', 'epsilon_greedy'. Defaults to 'pareto'.
     - skip_perfect_score: Whether to skip updating the candidate if it achieves a perfect score on the minibatch.
     - batch_sampler: Strategy for selecting training examples. Can be a [BatchSampler](src/gepa/strategies/batch_sampler.py) instance or a string for a predefined strategy from ['epoch_shuffled']. Defaults to 'epoch_shuffled', which creates an [EpochShuffledBatchSampler](src/gepa/strategies/batch_sampler.py).
     - reflection_minibatch_size: The number of examples to use for reflection in each proposal step. Defaults to 3. Only valid when batch_sampler='epoch_shuffled' (default), and is ignored otherwise.
@@ -234,7 +234,7 @@ def optimize(
     if isinstance(candidate_selection_strategy, str):
         factories = {
             "pareto": lambda: ParetoCandidateSelector(rng=rng),
-            "pareto_softmax_sum": lambda: ParetoSoftmaxSumCandidateSelector(rng=rng),
+            "pareto_softmax": lambda: ParetoSoftmaxCandidateSelector(rng=rng),
             "current_best": lambda: CurrentBestCandidateSelector(),
             "epsilon_greedy": lambda: EpsilonGreedyCandidateSelector(epsilon=0.1, rng=rng),
         }
@@ -244,7 +244,7 @@ def optimize(
         except KeyError as exc:
             raise ValueError(
                 f"Unknown candidate_selector strategy: {candidate_selection_strategy}. "
-                "Supported strategies: 'pareto', 'pareto_softmax_sum', 'current_best', 'epsilon_greedy'"
+                "Supported strategies: 'pareto', 'pareto_softmax', 'current_best', 'epsilon_greedy'"
             ) from exc
     elif isinstance(candidate_selection_strategy, CandidateSelector):
         candidate_selector = candidate_selection_strategy

--- a/src/gepa/gepa_utils.py
+++ b/src/gepa/gepa_utils.py
@@ -2,6 +2,7 @@
 # https://github.com/gepa-ai/gepa
 
 
+import math
 import random
 from typing import Any, Mapping
 
@@ -115,3 +116,52 @@ def select_program_candidate_from_pareto_front(
 
     curr_prog_id = rng.choice(sampling_list)
     return curr_prog_id
+
+
+def select_program_candidate_from_pareto_front_softmax_sum(
+    pareto_front_programs: Mapping[Any, set[int]],
+    program_val_subscores: list[Mapping[Any, float]],
+    rng: random.Random,
+    temperature: float = 1.0,
+) -> int:
+    program_sum_scores = {
+        prog_idx: sum(subscores.values()) if subscores else float("-inf")
+        for prog_idx, subscores in enumerate(program_val_subscores)
+    }
+    new_program_at_pareto_front_valset = remove_dominated_programs(
+        pareto_front_programs, scores=program_sum_scores
+    )
+    pareto_programs = sorted({prog_idx for front in new_program_at_pareto_front_valset.values() for prog_idx in front})
+    assert len(pareto_programs) > 0
+
+    if temperature <= 0:
+        raise ValueError("temperature must be positive")
+
+    summed_weights = {prog_idx: 0.0 for prog_idx in pareto_programs}
+    for val_id in pareto_front_programs.keys():
+        scores = [
+            program_val_subscores[prog_idx].get(val_id, float("-inf")) for prog_idx in pareto_programs
+        ]
+        max_score = max(scores)
+        if max_score == float("-inf"):
+            continue
+        weights = [math.exp((score - max_score) / temperature) for score in scores]
+        total_weight = sum(weights)
+        if total_weight <= 0.0:
+            continue
+        for prog_idx, weight in zip(pareto_programs, weights, strict=True):
+            summed_weights[prog_idx] += weight / total_weight
+
+    total_weight = sum(summed_weights.values())
+    if total_weight <= 0.0:
+        return rng.choice(pareto_programs)
+
+    threshold = rng.random() * total_weight
+    cumulative = 0.0
+    for prog_idx in pareto_programs:
+        weight = summed_weights[prog_idx]
+        cumulative += weight
+        if threshold <= cumulative:
+            return prog_idx
+
+    return pareto_programs[-1]

--- a/src/gepa/gepa_utils.py
+++ b/src/gepa/gepa_utils.py
@@ -118,7 +118,7 @@ def select_program_candidate_from_pareto_front(
     return curr_prog_id
 
 
-def select_program_candidate_from_pareto_front_softmax_sum(
+def select_program_candidate_from_pareto_front_softmax(
     pareto_front_programs: Mapping[Any, set[int]],
     program_val_subscores: list[Mapping[Any, float]],
     rng: random.Random,

--- a/src/gepa/strategies/candidate_selector.py
+++ b/src/gepa/strategies/candidate_selector.py
@@ -7,7 +7,7 @@ from gepa.core.state import GEPAState
 from gepa.gepa_utils import (
     idxmax,
     select_program_candidate_from_pareto_front,
-    select_program_candidate_from_pareto_front_softmax_sum,
+    select_program_candidate_from_pareto_front_softmax,
 )
 from gepa.proposer.reflective_mutation.base import CandidateSelector
 
@@ -28,7 +28,7 @@ class ParetoCandidateSelector(CandidateSelector):
         )
 
 
-class ParetoSoftmaxSumCandidateSelector(CandidateSelector):
+class ParetoSoftmaxCandidateSelector(CandidateSelector):
     def __init__(self, rng: random.Random | None, temperature: float = 1.0):
         if rng is None:
             self.rng = random.Random(0)
@@ -38,7 +38,7 @@ class ParetoSoftmaxSumCandidateSelector(CandidateSelector):
 
     def select_candidate_idx(self, state: GEPAState) -> int:
         assert len(state.program_full_scores_val_set) == len(state.program_candidates)
-        return select_program_candidate_from_pareto_front_softmax_sum(
+        return select_program_candidate_from_pareto_front_softmax(
             state.program_at_pareto_front_valset,
             state.prog_candidate_val_subscores,
             self.rng,

--- a/src/gepa/strategies/candidate_selector.py
+++ b/src/gepa/strategies/candidate_selector.py
@@ -4,7 +4,11 @@
 import random
 
 from gepa.core.state import GEPAState
-from gepa.gepa_utils import idxmax, select_program_candidate_from_pareto_front
+from gepa.gepa_utils import (
+    idxmax,
+    select_program_candidate_from_pareto_front,
+    select_program_candidate_from_pareto_front_softmax_sum,
+)
 from gepa.proposer.reflective_mutation.base import CandidateSelector
 
 
@@ -21,6 +25,24 @@ class ParetoCandidateSelector(CandidateSelector):
             state.program_at_pareto_front_valset,
             state.program_full_scores_val_set,
             self.rng,
+        )
+
+
+class ParetoSoftmaxSumCandidateSelector(CandidateSelector):
+    def __init__(self, rng: random.Random | None, temperature: float = 1.0):
+        if rng is None:
+            self.rng = random.Random(0)
+        else:
+            self.rng = rng
+        self.temperature = temperature
+
+    def select_candidate_idx(self, state: GEPAState) -> int:
+        assert len(state.program_full_scores_val_set) == len(state.program_candidates)
+        return select_program_candidate_from_pareto_front_softmax_sum(
+            state.program_at_pareto_front_valset,
+            state.prog_candidate_val_subscores,
+            self.rng,
+            temperature=self.temperature,
         )
 
 


### PR DESCRIPTION
### Motivation
- Prefer sampling from all non-dominated programs per validation task rather than using a single aggregated score per program.
- Treat missing per-task subscores as `-inf` so absent scores do not inflate probabilities.
- Expose a temperature parameter to control exploration vs exploitation in Pareto softmax sampling.
- Fall back to uniform sampling only if numerical issues cause non-positive total weight.

### Description
- Implemented `select_program_candidate_from_pareto_front_softmax_sum` to compute a per-task softmax over non-dominated programs, sum normalized per-task probabilities, and sample from the aggregate distribution, while treating missing scores as `float("-inf")` and validating `temperature > 0`.
- Threaded a `temperature: float = 1.0` parameter through the `ParetoSoftmaxSumCandidateSelector` class and its call to the selector function.
- Updated the public API to include the `pareto_softmax_sum` option for `candidate_selection_strategy` and added the selector factory entry.
- Kept the fallback behavior to uniformly choose from Pareto programs when the aggregated total weight is non-positive.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db0fada74832d8bc4b2bf7a19b1e0)